### PR TITLE
Update docker build action dependencies

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -24,7 +24,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v2
@@ -32,19 +32,21 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and Push Versioned Docker Image
         id: build-and-push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           context: .
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and Push Latest Docker Image
         id: build-and-push-latest
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           context: .
           push: true
+          provenance: false
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Updates some of the docker action dependencies to fix issues related to the latest versions of buildx.

- Updates docker/setup-buildx-action to v2
- Updates docker/build-push-action to v4
- Adds the `provenance: false` property to build-push-action to fix issue with multi-arch builds. See docker/setup-buildx-action#187